### PR TITLE
Bump rust-optimizer vesion in docs

### DIFF
--- a/Developing.md
+++ b/Developing.md
@@ -74,7 +74,7 @@ to run it is this:
 docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  cosmwasm/rust-optimizer:0.11.3
+  cosmwasm/rust-optimizer:0.11.4
 ```
 
 We must mount the contract code to `/code`. You can use a absolute path instead


### PR DESCRIPTION
Closes #49 

As we no longer have integration tests, but refer to an old optimizer