### PR TITLE
fix exception at bootup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-name = "{{project-name}}"
+name = "your-project-nam"
 version = "0.1.0"
-authors = ["{{authors}}"]
+authors = ["your-author-name"]
 edition = "2018"
 
 exclude = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "your-project-nam"
+name = "your-project-name"
 version = "0.1.0"
 authors = ["your-author-name"]
 edition = "2018"


### PR DESCRIPTION
By default running cargo build on the default package throws exception. Rename variables to prevent users from having to debug.